### PR TITLE
Set check_region to False for get_bucket function.

### DIFF
--- a/global.R
+++ b/global.R
@@ -35,7 +35,7 @@ ucsc_coord <- paste0("chr", default_chr, ":", as.character(default_start), "-", 
 
 # Initialize data from Amazon
 amazon <- "http://s3.amazonaws.com/dnalandscaper"
-t <- unlist(get_bucket(bucket = "dnalandscaper"))
+t <- unlist(get_bucket(bucket = "dnalandscaper", check_region = FALSE))
 amazon.filenames <- paste(amazon, t[grep("data", t)], sep = "/")
 
 ## HUMAN INITIALIZATION ##


### PR DESCRIPTION
When running DNAlandscapeR locally I was running into an issue where the call get_bucket(bucket = "dnalandscaper") was failing with the following error:

Error in parse_aws_s3_response(r, Sig, verbose = verbose) : 
  Forbidden (HTTP 403).

Looking into the actual return message of get_bucket revealed an "Access Denied" message.  After some research, I came across a solution, setting check_region to false, that when implemented allowed get_bucket to return the actual data at http://s3.amazonaws.com/dnalandscaper.  So if this option doesn't cause issues on your end, I think merging this small change might help other future users.